### PR TITLE
Fixed instantiation of Hamster Hashes in route_service.

### DIFF
--- a/app/services/shogun/route_service.rb
+++ b/app/services/shogun/route_service.rb
@@ -7,7 +7,7 @@ module Shogun
     include Singleton
 
     def initialize
-      @pages = Hamster.hash
+      @pages = Hamster::Hash[]
     end
 
     def [](path)
@@ -42,8 +42,8 @@ module Shogun
         set = json.each_with_object(Set.new) { |page, set| set.add(page["uuid"]) }
 
         unless Set.new(@pages.values.to_a) == set
-          @pages = json.inject(Hamster.hash) do |hash, page|
-            hash.put(page["path"].downcase, Hamster.hash("uuid" => page["uuid"], "languages" => page["languages"]))
+          @pages = json.inject(Hamster::Hash[]) do |hash, page|
+            hash.put(page["path"].downcase, Hamster::Hash["uuid" => page["uuid"], "languages" => page["languages"]])
           end
         end
       end

--- a/test/services/shogun/route_service_test.rb
+++ b/test/services/shogun/route_service_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class RouteServiceTest < ActiveSupport::TestCase
+
+  test "reloads the RouteService instance" do
+    @r = Shogun::RouteService.instance.reload!
+
+    # Ensure return from Reload (the @pages hash) is of type Hamster::Hash
+    assert Hamster::Hash === @r, "Expected Hamster::Hash, got #{@r.class.name}"
+  end
+
+end


### PR DESCRIPTION
Previously, route_service was instantiating hashes as Hamster.hash instead of Hamster::Hash[], this results in an integer return (see Object#hash in Ruby core).
